### PR TITLE
Class4/#1

### DIFF
--- a/class4/15652.py
+++ b/class4/15652.py
@@ -1,13 +1,13 @@
 # Ex_15652 N과 M(4): 실3
-def backtrack(list, min):
+def dfs(list, min):
     if len(list) == M:
         print(*list)
         return
 
     for i in range(min, N + 1):
-        backtrack(list + [i], i)
+        dfs(list + [i], i)
 
 
 N, M = map(int, input().split())
 
-backtrack([], 1)
+dfs([], 1)

--- a/class4/15657.py
+++ b/class4/15657.py
@@ -1,0 +1,14 @@
+# Ex_15657 N과 M(8)
+
+def dfs(list, num_index):
+    if len(list) == M:
+        print(*list)
+        return
+    
+    for i in range(num_index, N):
+        dfs(list + [num_list[i]], i)
+
+N, M = map(int, input().split())
+num_list = sorted(list(map(int, input().split())))
+
+dfs([], 0)

--- a/class4/15666.py
+++ b/class4/15666.py
@@ -1,0 +1,15 @@
+# Ex_15666 N과 M(12) 실2
+
+def dfs(list, num_index):
+    if len(list) == M:
+        print(*list)
+        return
+    
+    for i in range(num_index, N):
+        dfs(list + [num_list[i]], i)
+
+_, M = map(int, input().split())
+num_list = sorted(set(map(int, input().split()))) # 입력받은 리스트의 중복 제거 + 정렬
+N = len(num_list)
+
+dfs([], 0)


### PR DESCRIPTION
<!--
**사전 작업**
- Assignees self 지정
- Labels 지정
- Milestone 지정
-->

<!--
**주의 사항**
1. 고민 또는 엣지 케이스에 대해 설명할 때에는 Header3 (###) 속성으로 문제 링크를 첨부한다.
2. 고민 또는 엣지 케이스는 작성하지 않아도 된다.
3. 문제 리스트에는 링크를 첨부하지 않아도 된다.
### [문제번호 문제제목](문제링크)
-->

## What is this pr
#1 
<!--  
- 관련된 issue -> #2
- 참고 링크 or 정리 링크 -> [제목](url)
-->

## 문제 리스트

- [x] N과 M(4) -> #4 
- [x] N과 M(8)
- [x] N과 M(12)

## 고민
### 공통
1. 기존 코드
- dfs 함수의 종료 조건을 검사할 때 len(list)를 연산한다. `if len(list) == M`
- list의 최대 길이가 8이기 때문에 연산의 부하가 없다고 생각했기 때문에 사용했다. 
- 만약 list의 길이를 기억해서 매개변수로 넘긴다면 len(list)와 같은 O(n) 연산은 하지 않는다. `def dfs(list, min, len_list):`

2. 다른 방법과의 비교
- 매개변수를 추가한다면 dfs 함수가 스택 공간에 적재될 때마다 int 자료형의 크기만큼 메모리를 필요로 한다.
- 함수 호출 시마다 len(list)를 계산하면 메모리 공간은 차지하지 않지만 시간 복잡도가 늘어난다.

3.  결론
- 앞서 말한 것 처럼, list의 최대 길이가 8이기 때문에 len(list)를 매 번 계산하는 방식을 택했다. 여러분의 생각은?