### PR TITLE
[BDH]메뉴 리뉴얼

### DIFF
--- a/week_01/메뉴리뉴얼 시간초과.py
+++ b/week_01/메뉴리뉴얼 시간초과.py
@@ -1,0 +1,42 @@
+from itertools import combinations
+
+def power_set(size):
+    return [format(i, 'b').zfill(size) for i in range(1, 2 ** size)]
+
+def order_to_int(order, order_alpha):
+    return int(''.join([str(int(now_alpha in order)) for now_alpha in order_alpha]), 2)
+
+def decide_set_menu(set_menu_counter):
+    set_menu = []
+    for now_course in set_menu_counter.keys():
+        sorted_menu = sorted(set_menu_counter[now_course].items(), key=lambda x: -x[1])
+        max_cnt = 0 if not sorted_menu or sorted_menu[0][1] == 1 else sorted_menu[0][1]
+        for menu, cnt in sorted_menu:
+            if cnt != max_cnt:
+                break
+            set_menu.append(menu)
+    return sorted(set_menu)
+
+def set_menu_in_order(set_menu, order):
+    return set_menu & order == set_menu
+
+def count_set_menu(set_menu_counter, set_menu_order, course):
+    if set_menu_counter[course].get(set_menu_order, 0):
+        set_menu_counter[course][set_menu_order] += 1
+    else:
+        set_menu_counter[course][set_menu_order] = 1
+
+def solution(orders, course):
+    order_alphas = sorted(set(''.join(orders)))
+    order_int = [order_to_int(order, order_alphas) for order in orders]
+
+    set_menu_counter = {}
+    for now_course in course:
+        set_menu_counter[now_course] = {}
+        for set_menu in combinations(order_alphas, now_course):
+            for order in order_int:
+                set_menu_int = order_to_int(set_menu, order_alphas)
+                if set_menu_in_order(set_menu_int, order):
+                    set_menu_order = ''.join(set_menu)
+                    count_set_menu(set_menu_counter, set_menu_order, now_course)
+    return decide_set_menu(set_menu_counter)

--- a/week_01/메뉴리뉴얼 접근 실패.py
+++ b/week_01/메뉴리뉴얼 접근 실패.py
@@ -1,0 +1,49 @@
+def power_set(size):
+    return [format(i, 'b').zfill(size) for i in range(1, 2 ** size)]
+
+def orders_to_int(orders, alphas):
+    return [int(''.join([str(int(now_alpha in order)) for now_alpha in alphas]), 2) for order in orders]
+
+def int_to_order(order, alphas):
+    return ''.join([alphas[i] for i, v in enumerate(format(order, 'b').zfill(len(alphas))) if v == '1'])
+
+def find_set_menu(orders_combination):
+    value = orders_combination[0]
+    for i in range(len(orders_combination)):
+        value = value & orders_combination[i]
+    return 0 if not is_power_of_two(value) else value
+
+def is_power_of_two(value):
+    return value & (value - 1)
+
+def decide_set_menu(set_menu_counter, course):
+    set_menu = []
+    for now_course in course:
+        sorted_menu = sorted(set_menu_counter[now_course].items(), key=lambda x: -x[1])
+        max_cnt = 0 if not sorted_menu else sorted_menu[0][1]
+        for menu, cnt in sorted_menu:
+            if cnt != max_cnt:
+                break
+            set_menu.append(menu)
+    return sorted(set_menu)
+
+def solution(orders, course):
+    order_alphas = sorted(set(''.join(orders)))
+    order_integers = orders_to_int(orders, order_alphas)
+    orders_len = len(orders)
+    
+    set_menu_counter = {now_course: {} for now_course in course}
+    for now_set in power_set(orders_len):
+        if now_set.count('1') == 1:
+            continue
+        
+        orders_combination = [order_integers[i] for i in range(orders_len) if now_set[i] == '1']
+        possible_set_menu = find_set_menu(orders_combination)
+        if possible_set_menu:
+            menu = int_to_order(possible_set_menu, order_alphas)
+            course_cnt, orders_cnt = len(menu), len(orders_combination)
+            if not set_menu_counter[course_cnt].get(menu, 0):
+                set_menu_counter[course_cnt][menu] = orders_cnt
+            else:
+                set_menu_counter[course_cnt][menu] = max(set_menu_counter[course_cnt][menu], orders_cnt)
+    return decide_set_menu(set_menu_counter, course)

--- a/week_01/메뉴리뉴얼.py
+++ b/week_01/메뉴리뉴얼.py
@@ -26,11 +26,3 @@ def solution(orders, course):
                 set_menu_order = ''.join(sorted(set_menu))
                 count_set_menu(set_menu_counter, set_menu_order, now_course)
     return decide_set_menu(set_menu_counter)
-            
-
-
-orders = ["XYZ", "XWY", "WXA"]
-course = [2, 3, 4]
-
-# print(230 & 160 & 162)
-print(solution(orders, course))

--- a/week_01/메뉴리뉴얼.py
+++ b/week_01/메뉴리뉴얼.py
@@ -1,0 +1,36 @@
+from itertools import combinations
+
+def decide_set_menu(set_menu_counter):
+    set_menu = []
+    for now_course in set_menu_counter.keys():
+        sorted_menu = sorted(set_menu_counter[now_course].items(), key=lambda x: -x[1])
+        max_cnt = 0 if not sorted_menu or sorted_menu[0][1] == 1 else sorted_menu[0][1]
+        for menu, cnt in sorted_menu:
+            if cnt != max_cnt:
+                break
+            set_menu.append(menu)
+    return sorted(set_menu)
+
+def count_set_menu(set_menu_counter, set_menu_order, course):
+    if set_menu_counter[course].get(set_menu_order, 0):
+        set_menu_counter[course][set_menu_order] += 1
+    else:
+        set_menu_counter[course][set_menu_order] = 1
+
+def solution(orders, course):
+    set_menu_counter = {}
+    for now_course in course:
+        set_menu_counter[now_course] = {}
+        for order in orders:
+            for set_menu in combinations(order, now_course):
+                set_menu_order = ''.join(sorted(set_menu))
+                count_set_menu(set_menu_counter, set_menu_order, now_course)
+    return decide_set_menu(set_menu_counter)
+            
+
+
+orders = ["XYZ", "XWY", "WXA"]
+course = [2, 3, 4]
+
+# print(230 & 160 & 162)
+print(solution(orders, course))


### PR DESCRIPTION
<!--
**사전 작업**
- Assignees self 지정
- Labels 지정
- Milestone 지정
-->

<!--
**주의 사항**
1. 고민 또는 엣지 케이스에 대해 설명할 때에는 Header3 (###) 속성으로 문제 링크를 첨부한다.
2. 고민 또는 엣지 케이스는 작성하지 않아도 된다.
3. 문제 리스트에는 링크를 첨부하지 않아도 된다.
### [문제번호 문제제목](문제링크)
-->

## What is this pr
- #26 
<!--  
- 관련된 issue -> #2
- 참고 링크 or 정리 링크 -> [제목](url)
-->

## 문제 리스트

- 메뉴 리뉴얼

## 고민 <!--Optional-->
<!-- 코드 리뷰에서 중점적으로 볼 내용-->
<!-- 이해 못할 거 같은 문제 설명-->

<details markdown="1">
<summary>고민한거</summary>

- **메뉴 리뉴얼 접근 실패**
  - 문제 접근
    1. 메뉴의 알파벳들을 오름차순으로 줄 세움
       - ex) `["ABC", "BD", "XW"]` -> `['A', 'B', 'C', 'D', 'X', 'W']`
    2. `order`를 `int`로 바꿈
        - `"ABC"` -> `111000` -> `56`
        - `"BD"` -> `010100` -> `20`
        - `"XW"` -> `000011` -> `3` 
    3. `course`를 돌면서 `order`를 `combination`함.
        - ex) `course`가 `[2, 3]`일 때
        - `course == 2`
          - `[(56, 20), (56, 3), (20, 3)]`
        - `course == 3`
          - `[(56, 20, 3)]`
    4. `combination`들을 `&`연산함
       - `56 & 20` -> `111000 & 010100` -> `010000` -> `16`
    5. `&` 연산의 결과가 `2의 제곱수`라면 무시(1이 하나 -> **메뉴가 하나**)
    
  - 한계
    - 예제 케이스는 이런식으로 맞출 수 있는데 엣지케이스 같은 경우에는 답을 `["ABCD"]`하나밖에 못 찾음
    - 메뉴로 `combination`을 하면 안됨

- **메뉴 리뉴얼 시간 초과**
  - 문제 접근
    - 알파벳으로 `combination`을 함
    - 방식은 위와 동일
    
  - 한계
    - 알파벳으로 combination을 하게되면 없는 조합까지 괜히 만들게 됨.
      - ex) `"ABC", "EFG"`라고 하면 가능한 알파벳은 `A, B, C, E, F, G` 
      - 따라서 `"AB", "AC", ... , "ABCEFG"`를 만듦(그런데 "ABCEFG"는 필요가 없음!)
    - course 크기만큼 combination하게 함(course = 3이라고 치면)
      - `ABG`같은 전혀 나올 수 없는 조합을 만듦

- **해결 방법**
  - order마다 combination을 만듬
    - order = ["ABC", "EFG"], course = [2, 3]라고 하면
    - "ABC"에서
      - "AB", "AC", "BC", "ABC"
    - "EFG"에서
      - "EF", "EG", "FG"
    - 이렇게 하면 **`가능성`** 있는 조합들만 만들어지게 됨!

</details>

## 엣지 케이스 <!-- Optional-->
항목 1 | 항목 2 
----- | -----
orders | ["ABCD", "ABCD", "ABCD"]
course | [2,3,4]
answer | ['AB', 'ABC', 'ABCD', 'ABD', 'AC', 'ACD', 'AD', 'BC', 'BCD', 'BD', 'CD']
