### PR TITLE
[CJW] 가장 긴 증가하는 부분 수열2

### DIFF
--- a/naver/week01/12015_LIS2.py
+++ b/naver/week01/12015_LIS2.py
@@ -1,0 +1,29 @@
+# 가장 긴 증가하는 부분 수열 2
+
+def findSpot(element):
+    start, end = 0, len(dp) - 1
+
+    while start < end:
+        mid = (start + end) // 2
+
+        if dp[mid] < element:
+            start = mid + 1
+        elif dp[mid] == element:
+            return mid
+        else:
+            end = mid 
+            
+    return end
+        
+N = int(input())
+elements = list(map(int, input().split()))
+
+dp = [elements[0]]
+
+for element in elements:
+    if element > dp[-1]:
+        dp.append(element)
+    else:
+        dp[findSpot(element)] = element
+    
+print(len(dp))


### PR DESCRIPTION
<!--
**사전 작업**
- Assignees self 지정
- Labels 지정
- Milestone 지정
-->

<!--
**주의 사항**
1. 고민 또는 엣지 케이스에 대해 설명할 때에는 Header3 (###) 속성으로 문제 링크를 첨부한다.
2. 고민 또는 엣지 케이스는 작성하지 않아도 된다.
3. 문제 리스트에는 링크를 첨부하지 않아도 된다.
### [문제번호 문제제목](문제링크)
-->

## What is this pr

<!--  
- 관련된 issue -> #2
- 참고 링크 or 정리 링크 -> [제목](url)
-->
- #81
## 문제 리스트

- [x] [12015 가장 긴 증가하는 부분수열 2](https://www.acmicpc.net/problem/12015)

## 고민 <!--Optional-->
<!-- 코드 리뷰에서 중점적으로 볼 내용-->
<!-- 이해 못할 거 같은 문제 설명-->

- dp + 이분탐색 + 투포인터 문제를 해결하면 배열 자료구조를 익힌 것이라 생각.
- 아래 로직처럼 dp스럽게 접근하는 방법을 유추하기 힘든 문제였다.
- 일단 오름차순으로 원소를 쌓아나간다.
- 오름차순으로 부분수열을 만드는 과정에서 최댓값보다 작은 수가 나올 경우 대처가 중요하다.
- 위 경우 **오름차순을 유지하며 기존 배열의 원소를 교체**해 나간다. 두 경우가 나올 수 있다.
    1. 결국 마지막 원소까지 교체한 뒤라면 결과론적으로 교체된 배열이 가장 긴 수열이 된다.
    2. 마지막원소에 닿지 못했다면 dp[-1]을 제외한 배열은 하위호환 배열이기 때문에 고려대상이 안된다.    
## 엣지 케이스 <!-- Optional-->
