### PR TITLE
[CJW] 9월 2주차

### DIFF
--- a/boj/class5/1208.py
+++ b/boj/class5/1208.py
@@ -1,0 +1,46 @@
+# Ex_1208 부분수열의 합 2 [골1]
+
+def getSubset(length, start):
+    target = [0] * (1 << length)
+    for i in range(1 << length):
+        for j in range(length):
+            if (i & (1 << j)) > 0:
+                target[i] += nList[start + j]
+
+    return target
+
+
+N, S = map(int, input().split())
+nList = list(map(int, input().split()))
+answer = 0
+
+a = N // 2
+b = N - a
+
+left = sorted(getSubset(a, 0))
+right = sorted(getSubset(b, a), reverse=True)
+
+i, j = 0, 0
+while i < (1 << a) and j < (1 << b):
+
+    if left[i] + right[j] == S:
+        left_stack, right_stack = 1, 1
+
+        while i < ((1 << a) - 1) and left[i] == left[i + 1]:
+            left_stack += 1
+            i += 1
+
+        while j < ((1 << b) - 1) and right[j] == right[j + 1]:
+            right_stack += 1
+            j += 1
+
+        answer += left_stack * right_stack
+        i, j = i + 1, j + 1
+
+    elif left[i] + right[j] < S:
+        i += 1
+
+    else:
+        j += 1
+
+print(answer if S != 0 else answer - 1)

--- a/boj/class5/1644.py
+++ b/boj/class5/1644.py
@@ -1,0 +1,41 @@
+# Ex_1644 소수의 연속합 [골3]
+import math
+from collections import defaultdict
+
+N = int(input())
+
+primes = []
+isPrime = [True] * (N + 1)
+sumDict = defaultdict(int)
+answer = 0
+
+# set prime bool
+for i in range(2, int(math.sqrt(N)) + 1):
+    if isPrime[i]:
+        j = 2
+        while i * j <= N:
+            isPrime[i * j] = False
+            j += 1
+
+# set prime num
+for i in range(2, N + 1):
+    if isPrime[i]:
+        primes.append(i)
+
+# prefix sum
+for i in range(len(primes)):
+    sumPrime = primes[i]
+
+    if sumPrime == N:
+        answer += 1
+
+    for j in range(i + 1, len(primes)):
+        sumPrime += primes[j]
+
+        if sumPrime > N:
+            break
+
+        if sumPrime == N:
+            answer += 1
+
+print(answer)

--- a/boj/class5/16566.py
+++ b/boj/class5/16566.py
@@ -1,0 +1,35 @@
+# Ex_16566 카드게임 [플5]
+# upper bound
+def upperBound(target):
+    s, e = 0, M
+
+    while s < e:
+        mid = (s + e) // 2
+        if cards[mid] <= target:
+            s = mid + 1
+        else:
+            e = mid
+    return e
+
+
+def find(x):
+    if graph[x] != x:
+        graph[x] = find(graph[x])
+    return graph[x]
+
+
+def union(child, parent):
+    if parent < M:
+        graph[find(child)] = find(parent)
+
+
+N, M, K = map(int, input().split())
+cards = sorted(map(int, input().split()))
+cCards = list(map(int, input().split()))
+graph = list(i for i in range(M))
+
+for cCard in cCards:
+    index = find(upperBound(cCard))
+    print(cards[index])
+
+    union(index, index + 1)

--- a/boj/class5/2143.py
+++ b/boj/class5/2143.py
@@ -1,0 +1,23 @@
+# Ex_2143 두 배열의 합 [골3]
+from collections import defaultdict
+
+T = int(input())
+
+n = int(input())
+aList = list(map(int, input().split()))
+aSum = defaultdict(int)
+
+m = int(input())
+bList = list(map(int, input().split()))
+
+answer = 0
+
+for i in range(n):
+    for j in range(i, n):
+        aSum[sum(aList[i:j + 1])] += 1
+
+for i in range(m):
+    for j in range(i, m):
+        answer += aSum[T - sum(bList[i: j + 1])]
+
+print(answer)


### PR DESCRIPTION
## What is this pr

<!--  
- 관련된 issue -> #2
- 참고 링크 or 정리 링크 -> [제목](url)
-->

- Resolve: #115 

## 문제 리스트

- [x] 1208 부분수열의합 2
- [x] 1644 소수의 연속합
- [x] 2143 두 배열의합
- [x] 16566 카드게임

## 고민 <!--Optional-->
<!-- 코드 리뷰에서 중점적으로 볼 내용-->
<!-- 이해 못할 거 같은 문제 설명-->

### 두 배열의 합
문제
- 두 배열이 있고, 원하는 합을 구한다.

요약
- 배열이 두개 있고 합의 경우의수를 탐색하는 문제라고 볼 수 있다.
- 동적으로 누적합을 구한다면 O(N^2)이 된다. 따라서 전처리를 통해 양쪽의 누적합을 미리 구해둬야 한다.
- 또한 이진탐색으로 접근해 시간복잡도를 줄여야 한다.

풀이
- 위 요약과는 달리 왼쪽 배열의 누적합을 구하고, 오른쪽 배열에선 원하는 값을 찾는 방식으로 해결했다.
- a배열은 합을 인덱스로 하고, 개수를 밸류로 하는 배열을 저장한다.
- b배열을 순회할 때 `a배열[타겟 값 - 누적합]` 을 구한다면, 답을 이끌어낼 수 있다.

Keep: 누적합을 처음 시도했으며 다음엔 적용할 수 있어야 한다, 배열을 둘로 나눠푸는 접근법, 이진탐색 고려

---

### 소수의 연속합
문제
- 연속되는 소수끼리 합해 원하는 합을 구한다.

요약
- 에라토스테네스의 체로 소수를 걸러낸다.
- 누적합의 배열을 구하면서 상한을 걸어 시간초과를 피한다.

Keep: 누적합을 적용했으며 정석적이지 않은 문제도 도전해야한다.

---

### 부분수열의 합 2
문제
- 원하는 값을 구할 수 있는 조합의 개수를 구한다.

요약
- O(2^N), N <= 40 이다. 배열을 둘로 나눠푸는 접근법을 알았기 때문에 O(2^M) M <= 20으로 풀었다.
- 비트마스킹을 활용해 조합을 boolean 배열로 나타냈으며 코드의 질을 높였다.

Keep: 누적합을 응용했으며 실전에서 맞아야 한다. 비트마스킹을 활용했다.

---

### 카드게임
문제
- a 배열을 순회하며 요소보다 큰값을 b배열에서 소모한다.

요약
- a배열에서 요소보다 큰 값을 찾기 위해 upperBound를 이분탐색해야한다.
- b배열에서 값을 소모하기 위해 union find를 활용한다.
 
Keep: 이진탐색의 lower bound, upper bound 개념이 있다는걸 처음 알았다. union find를 처음 활용했지만 어렵지 않았다. 바로 실전에 적용해도 될 것 같다

---

## 엣지 케이스 <!-- Optional-->
